### PR TITLE
Update publish-to-docker-hub.yml

### DIFF
--- a/.github/workflows/publish-to-docker-hub.yml
+++ b/.github/workflows/publish-to-docker-hub.yml
@@ -36,7 +36,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: rikvisser/easy-icecast2
+          images: rikvissermedia/easy-icecast2
 
       - name: Build and push Docker image
         id: push


### PR DESCRIPTION
This pull request includes a small but important change to the Docker image repository name in the GitHub Actions workflow file. The change updates the image name to reflect the correct repository.

* [`.github/workflows/publish-to-docker-hub.yml`](diffhunk://#diff-9dc003341d581b9b5a715816d14893c534729d7a0d0bb1062b98e24225a395d4L39-R39): Changed the Docker image name from `rikvisser/easy-icecast2` to `rikvissermedia/easy-icecast2`.