### PR TITLE
Refactor Dockerfile to use apt-get for package management and improve…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ LABEL Name=easyicecast-2 maintainer="Rik Visser <r.visser@rikvissermedia.nl>" gi
 
 RUN addgroup --system icecast2 && adduser --system --no-create-home --disabled-password --ingroup icecast2 icecast2
 
-RUN apt update && apt upgrade -y && \
-    apt install -y icecast2 && \
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y icecast2 && \
     sed -i "s#ENABLE=.*#ENABLE=true#" /etc/default/icecast2 && \
     cat /etc/default/icecast2 && \
-    apt autoremove && apt clean && \
+    apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change updates the package management commands to use `apt-get` instead of `apt`.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L7-R11): Replaced `apt` commands with `apt-get` for updating, upgrading, installing, autoremoving, and cleaning packages.… cleanup commands