### PR TITLE
Remove maintainer label from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM ubuntu:focal
 
-LABEL Name=easyicecast-2 maintainer="Rik Visser <r.visser@rikvissermedia.nl>" github="https://github.com/rikvisser-tech/easy-icecast2"
 
 RUN addgroup --system icecast2 && adduser --system --no-create-home --disabled-password --ingroup icecast2 icecast2
 


### PR DESCRIPTION
This pull request includes a minor change to the `Dockerfile`. The change removes the maintainer label, which included the maintainer's name, email, and GitHub URL.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3): Removed the maintainer label containing the maintainer's name, email, and GitHub URL.